### PR TITLE
Extract and Forward Payload to Network Layer, Develop GFSK Demodulation Chain

### DIFF
--- a/flowgraphs/rx_flowgraph.grc
+++ b/flowgraphs/rx_flowgraph.grc
@@ -37,7 +37,7 @@ blocks:
   id: variable
   parameters:
     comment: ''
-    value: 30.72M
+    value: 30.72e6
   states:
     bus_sink: false
     bus_source: false
@@ -145,7 +145,7 @@ blocks:
   id: variable
   parameters:
     comment: ''
-    value: 30.72M
+    value: 30.72e6
   states:
     bus_sink: false
     bus_source: false

--- a/flowgraphs/rx_flowgraph.py
+++ b/flowgraphs/rx_flowgraph.py
@@ -70,7 +70,7 @@ class rx_flowgraph(gr.top_block, Qt.QWidget):
         self.threshold = threshold = 450
         self.tcp_port = tcp_port = '52001'
         self.sync_word = sync_word = 1
-        self.samp_rate = samp_rate = 30.72M
+        self.samp_rate = samp_rate = 30.72e6
         self.preamble = preamble = 0b10101010
         self.payload_len = payload_len = 128
         self.host_ip = host_ip = '127.0.0.1'
@@ -79,7 +79,7 @@ class rx_flowgraph(gr.top_block, Qt.QWidget):
         self.center_freq = center_freq = 915e6
         self.RF_gain = RF_gain = 30
         self.K = K = 8
-        self.Bandwith = Bandwith = 30.72M
+        self.Bandwith = Bandwith = 30.72e6
 
         ##################################################
         # Blocks


### PR DESCRIPTION
Resolved the GFSK modulation issue by implementing a full demodulation pipeline using GNU Radio. This chain is assumed to correctly recover transmitted bits from the incoming RF stream and outputs clean packets as PDUs. Additionally, the demodulated packet stream is now correctly parsed and payloads are extracted and sent to the network layer (main.py). There are still some variables to be set but this can be done in the testing phase. 

<img width="1273" height="753" alt="image" src="https://github.com/user-attachments/assets/d262cf79-bb7a-4c9e-a7d0-38154181c2eb" />



